### PR TITLE
feat: 프로필 이미지 업로드

### DIFF
--- a/src/api/image.ts
+++ b/src/api/image.ts
@@ -1,0 +1,22 @@
+import axiosInstance from "./axiosInstance";
+
+// presigned URL 요청
+export const postPresignedUrl = async (
+  filename: string,
+  contentType: string,
+  fileSize: number
+) => {
+  const res = await axiosInstance.post(
+    "/api/users/me/profile/image/upload-url",
+    { filename, contentType, fileSize }
+  );
+  return res.data;
+};
+
+// 서버에 objectKey 보내기
+export const patchProfileImage = async (objectKey: string) => {
+  const res = await axiosInstance.patch("/api/users/me/profile/image", {
+    objectKey
+  });
+  return res.data;
+};

--- a/src/components/find/Follow.tsx
+++ b/src/components/find/Follow.tsx
@@ -1,0 +1,14 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { useInfoData } from "@/hooks/queries/useInfoData";
+
+const Follow = () => {
+  const { data: user } = useInfoData();
+  return (
+    <Avatar className="size-10">
+      <AvatarImage src="" alt="@shadcn" className="grayscale" />
+      <AvatarFallback>{user?.nickname.slice(0, 2)}</AvatarFallback>
+    </Avatar>
+  );
+};
+
+export default Follow;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -12,6 +12,8 @@ import type { FollowItem } from "@/types/follow";
 import { useDeleteFollower } from "@/hooks/mutations/useDeleteFollower";
 import { useDeleteFollowing } from "@/hooks/mutations/useDeleteFollowing";
 import { useInfoData } from "@/hooks/queries/useInfoData";
+import { Avatar, AvatarImage } from "@radix-ui/react-avatar";
+import { getProfileImageUrl } from "@/utils/image";
 
 const Header = () => {
   const { data: user } = useInfoData();
@@ -44,10 +46,20 @@ const Header = () => {
           </PopoverTrigger>
           <PopoverContent className="w-80" align="end"></PopoverContent>
         </Popover>
+        {user?.profileImageKey ? (
+          <Avatar className="w-10 h-10 rounded-full overflow-hidden">
+            <AvatarImage
+              className="object-cover w-full h-full"
+              src={getProfileImageUrl(user.profileImageKey)}
+              alt="프로필 이미지"
+            />
+          </Avatar>
+        ) : (
+          <div className="flex justify-center items-center w-10 h-10 bg-[#F3F4F6] rounded-full text-sm font-bold">
+            {user?.nickname.slice(0, 2)}
+          </div>
+        )}
 
-        <div className="flex justify-center items-center w-10 h-10 bg-[#F3F4F6] rounded-full text-sm font-bold">
-          {user?.nickname.slice(0, 2)}
-        </div>
         <div className="flex flex-col justify-center">
           <div className="text-base font-semibold">{user?.nickname}</div>
           <div className="flex gap-3 text-xs font-medium text-gray-500">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,11 +1,7 @@
 import { FiChevronLeft, FiChevronRight, FiSettings } from "react-icons/fi";
 import { BiHomeAlt } from "react-icons/bi";
 import { LuCalendar, LuSearch } from "react-icons/lu";
-import {
-  IoFileTraySharp,
-  IoLogInOutline,
-  IoLogOutOutline
-} from "react-icons/io5";
+import { IoLogInOutline, IoLogOutOutline } from "react-icons/io5";
 import { NavLink, useNavigate } from "react-router";
 import { cn } from "@/lib/utils";
 import Logo from "@/assets/everyvent-logo-basic.png";
@@ -77,7 +73,7 @@ const Sidebar = ({ isOpen, onToggle }: SidebarProps) => {
         </NavLink>
 
         <NavLink
-          to="/calendar"
+          to="/calendars"
           className={({ isActive }) => itemClass(isActive, isOpen)}
         >
           <LuCalendar size={18} />
@@ -85,7 +81,7 @@ const Sidebar = ({ isOpen, onToggle }: SidebarProps) => {
         </NavLink>
 
         <NavLink
-          to="/find"
+          to="/finds"
           className={({ isActive }) => itemClass(isActive, isOpen)}
         >
           <LuSearch size={18} />
@@ -93,15 +89,7 @@ const Sidebar = ({ isOpen, onToggle }: SidebarProps) => {
         </NavLink>
 
         <NavLink
-          to="/received"
-          className={({ isActive }) => itemClass(isActive, isOpen)}
-        >
-          <IoFileTraySharp size={18} />
-          {isOpen && <span className="text-sm">수신함</span>}
-        </NavLink>
-
-        <NavLink
-          to="/setting"
+          to="/settings"
           className={({ isActive }) => itemClass(isActive, isOpen)}
         >
           <FiSettings size={18} />

--- a/src/components/profile/ProfileUpload.tsx
+++ b/src/components/profile/ProfileUpload.tsx
@@ -2,15 +2,21 @@ import ProfileBasic from "@/assets/profile/profile-basic.png";
 import { MdOutlineUpload } from "react-icons/md";
 import { useRef, useState, useEffect, type ChangeEvent } from "react";
 import { Avatar, AvatarImage } from "../ui/avatar";
+import { FaRegTrashAlt } from "react-icons/fa";
 
 interface ProfileUploadProps {
-  onSelectFile: (file: File) => void;
+  onSelectFile: (file: File | null) => void;
 }
 
 const ProfileUpload = ({ onSelectFile }: ProfileUploadProps) => {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const removeImage = () => {
+    setPreviewUrl(null);
+    onSelectFile(null);
+  };
 
   const imageUploadHandler = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -33,13 +39,23 @@ const ProfileUpload = ({ onSelectFile }: ProfileUploadProps) => {
   return (
     <div className="flex flex-col items-center">
       <div className="relative py-4">
-        <Avatar className="w-[100px] h-[100px]">
-          <AvatarImage
-            src={previewUrl ?? ProfileBasic}
-            alt="프로필사진"
-            className="object-cover w-full h-full"
-          />
-        </Avatar>
+        <div className="relative w-[100px] h-[100px] group">
+          <Avatar className="h-full w-full">
+            <AvatarImage
+              src={previewUrl ?? ProfileBasic}
+              alt="프로필사진"
+              className="object-cover w-full h-full"
+            />
+            {/* 호버시 */}
+            <button
+              type="button"
+              className="absolute inset-0 flex items-center justify-center rounded-full bg-black/30 backdrop-blur-sm opacity-0 scale-90 group-hover:opacity-100  group-hover:scale-100 transition-all duration-200"
+              onClick={removeImage}
+            >
+              <FaRegTrashAlt className="text-white text-xl" size={30} />
+            </button>
+          </Avatar>
+        </div>
         <input
           ref={inputRef}
           id="profile-upload"

--- a/src/components/profile/ProfileUpload.tsx
+++ b/src/components/profile/ProfileUpload.tsx
@@ -1,21 +1,59 @@
 import ProfileBasic from "@/assets/profile/profile-basic.png";
 import { MdOutlineUpload } from "react-icons/md";
+import { useRef, useState, useEffect, type ChangeEvent } from "react";
+import { Avatar, AvatarImage } from "../ui/avatar";
 
-const ProfileUpload = () => {
+interface ProfileUploadProps {
+  onSelectFile: (file: File) => void;
+}
+
+const ProfileUpload = ({ onSelectFile }: ProfileUploadProps) => {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const imageUploadHandler = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+
+    onSelectFile(file);
+
+    e.target.value = "";
+  };
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
   return (
     <div className="flex flex-col items-center">
       <div className="relative py-4">
-        <img
-          src={ProfileBasic}
-          alt="프로필사진"
-          className="w-[60px] h-[60px]"
+        <Avatar className="w-[100px] h-[100px]">
+          <AvatarImage
+            src={previewUrl ?? ProfileBasic}
+            alt="프로필사진"
+            className="object-cover w-full h-full"
+          />
+        </Avatar>
+        <input
+          ref={inputRef}
+          id="profile-upload"
+          type="file"
+          accept="image/png, image/jpeg"
+          className="hidden"
+          onChange={imageUploadHandler}
         />
-        <button className="absolute left-[45px] top-[55px] w-[22px] h-[22px] rounded-[100%] bg-[#92A4FF] flex justify-center items-center">
+        <label
+          htmlFor="profile-upload"
+          className="absolute left-[75px] top-[90px] w-[26px] h-[26px] rounded-full bg-[#92A4FF] flex justify-center items-center cursor-pointer hover:bg-[#7C8FFF]"
+        >
           <MdOutlineUpload className="text-white" />
-        </button>
-      </div>
-      <div className="text-sm text-[#555555]">
-        프로필 사진을 업로드해보세요.
+        </label>
       </div>
     </div>
   );

--- a/src/hooks/mutations/usePatchProfile.ts
+++ b/src/hooks/mutations/usePatchProfile.ts
@@ -1,10 +1,13 @@
 import { patchUserIntroduction, patchUserNickname } from "@/api/userApi";
+import { patchProfileImage } from "@/api/image";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
+import type { User } from "@/types/user";
 
 type PatchProfileInput = {
   name: string;
   introduction: string;
+  profileImageKey?: string;
 };
 
 export function usePatchProfile() {
@@ -12,14 +15,45 @@ export function usePatchProfile() {
   const navigate = useNavigate();
 
   return useMutation({
-    mutationFn: async ({ name, introduction }: PatchProfileInput) => {
-      const tasks = [patchUserNickname(name)];
-      if (introduction.trim()) tasks.push(patchUserIntroduction(introduction));
-      await Promise.all(tasks);
+    mutationFn: async ({
+      name,
+      introduction,
+      profileImageKey
+    }: PatchProfileInput) => {
+      const jobs: Promise<unknown>[] = [];
+
+      if (name.trim()) jobs.push(patchUserNickname(name.trim()));
+
+      if (introduction.trim())
+        jobs.push(patchUserIntroduction(introduction.trim()));
+
+      if (profileImageKey) jobs.push(patchProfileImage(profileImageKey));
+
+      await Promise.all(jobs);
     },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["userInfo"] });
+
+    onSuccess: async (_data, variables) => {
+      queryClient.setQueryData<User>(["user", "userInfo"], (prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          nickname: variables.name.trim()
+            ? variables.name.trim()
+            : prev.nickname,
+          introduction: variables.introduction.trim()
+            ? variables.introduction.trim()
+            : prev.introduction,
+          profileImageKey: variables.profileImageKey ?? prev.profileImageKey
+        };
+      });
+
+      await queryClient.invalidateQueries({ queryKey: ["user", "userInfo"] });
+
       navigate("/", { replace: true });
+    },
+
+    onError: () => {
+      // TODO: 에러 처리 필요
     }
   });
 }

--- a/src/hooks/mutations/usePatchProfile.ts
+++ b/src/hooks/mutations/usePatchProfile.ts
@@ -7,7 +7,7 @@ import type { User } from "@/types/user";
 type PatchProfileInput = {
   name: string;
   introduction: string;
-  profileImageKey?: string;
+  profileImageKey: string | null;
 };
 
 export function usePatchProfile() {

--- a/src/pages/FindPage.tsx
+++ b/src/pages/FindPage.tsx
@@ -1,0 +1,11 @@
+import Follow from "@/components/find/Follow";
+
+const FindPage = () => {
+  return (
+    <div>
+      <Follow />
+    </div>
+  );
+};
+
+export default FindPage;

--- a/src/pages/ProfileSettingPage.tsx
+++ b/src/pages/ProfileSettingPage.tsx
@@ -83,7 +83,11 @@ const ProfileSettingPage = () => {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [fileError, setFileError] = useState<string | null>(null);
 
-  const onSelectFile = (file: File) => {
+  const onSelectFile = (file: File | null) => {
+    if (!file) {
+      setSelectedFile(null);
+      return;
+    }
     const ext = validateProfileImage(file);
     if (!ext) {
       setFileError("jpg, jpeg, png 파일만 업로드할 수 있습니다.");

--- a/src/pages/ProfileSettingPage.tsx
+++ b/src/pages/ProfileSettingPage.tsx
@@ -17,9 +17,10 @@ import {
   AlertDialogAction
 } from "@/components/ui/alert-dialog";
 import { useState } from "react";
+import { validateProfileImage } from "@/utils/image";
+import { uploadProfileImage } from "@/services/profileImageUpload";
 
 const schema = z.object({
-  // TODO: 프로필 이미지 설정 추가
   name: z.string().min(2, { message: "2 글자 이상 입력해주세요." }),
   introduction: z.string().max(100)
 });
@@ -48,13 +49,22 @@ const ProfileSettingPage = () => {
 
   const introductionValue = watch("introduction") ?? "";
 
-  const { mutateAsync, isPending, reset } = usePatchProfile();
+  const { mutateAsync, isPending } = usePatchProfile();
   const [openServerError, setOpenServerError] = useState(false);
 
   const onSubmit: SubmitHandler<ProfileFormField> = async (data) => {
     try {
-      reset();
-      await mutateAsync(data);
+      let profileImageKey: string | undefined;
+
+      if (selectedFile) {
+        profileImageKey = await uploadProfileImage(selectedFile);
+      }
+
+      await mutateAsync({
+        name: data.name,
+        introduction: data.introduction,
+        profileImageKey
+      });
     } catch (error: unknown) {
       console.error("프로필 수정 에러: ", error);
       if (axios.isAxiosError(error) && error.response?.status === 409) {
@@ -68,15 +78,31 @@ const ProfileSettingPage = () => {
     }
   };
 
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [fileError, setFileError] = useState<string | null>(null);
+
+  const onSelectFile = (file: File) => {
+    const ext = validateProfileImage(file);
+    if (!ext) {
+      setFileError("jpg, jpeg, png 파일만 업로드할 수 있습니다.");
+      setSelectedFile(null);
+      return;
+    }
+
+    setFileError(null);
+    setSelectedFile(file);
+  };
+
   return (
     <>
-      <div className="bg-white/80 w-[440px] h-[600px] rounded-xl p-10 overflow-y-auto overlay-scrollbar">
+      <div className="bg-white/80 w-[440px] h-[620px] rounded-xl p-10 overflow-y-auto overlay-scrollbar">
         <div className="flex flex-col items-center justify-center">
           <div className="text-2xl font-semibold pb-2">프로필 설정</div>
           <div className="text-md text-[#555555] font-regular">
             서비스 이용을 위한 기본 정보를 입력해주세요.
           </div>
-          <ProfileUpload />
+          <ProfileUpload onSelectFile={onSelectFile} />
+          {fileError && <p className="text-xs text-[#F24539]">{fileError}</p>}
           <form
             onSubmit={handleSubmit(onSubmit)}
             className="flex flex-col gap-6 pt-6"
@@ -91,7 +117,6 @@ const ProfileSettingPage = () => {
                   {...register("name", {
                     onChange: () => {
                       clearErrors("name");
-                      reset();
                     }
                   })}
                   placeholder="다른 사용자에게 표시될 이름입니다."
@@ -113,7 +138,6 @@ const ProfileSettingPage = () => {
                   {...register("introduction", {
                     onChange: (e) => {
                       setValue("introduction", e.target.value.slice(0, 100));
-                      reset();
                     }
                   })}
                   placeholder="자신을 간단히 소개해주세요."

--- a/src/pages/ProfileSettingPage.tsx
+++ b/src/pages/ProfileSettingPage.tsx
@@ -54,10 +54,12 @@ const ProfileSettingPage = () => {
 
   const onSubmit: SubmitHandler<ProfileFormField> = async (data) => {
     try {
-      let profileImageKey: string | undefined;
+      let profileImageKey: string | null;
 
       if (selectedFile) {
         profileImageKey = await uploadProfileImage(selectedFile);
+      } else {
+        profileImageKey = null;
       }
 
       await mutateAsync({

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -26,7 +26,7 @@ export const router = createBrowserRouter([
       {
         Component: PrivateRoute,
         children: [
-          { path: "calendar", Component: CalendarPage },
+          { path: "calendars", Component: CalendarPage },
           { path: "profile-setting", Component: ProfileSettingPage }
         ]
       },

--- a/src/services/profileImageUpload.ts
+++ b/src/services/profileImageUpload.ts
@@ -1,0 +1,23 @@
+import { postPresignedUrl } from "@/api/image";
+import { uploadToS3 } from "./s3Upload";
+import { getExtension } from "@/utils/image";
+
+export const uploadProfileImage = async (file: File) => {
+  const ext = getExtension(file);
+  if (!ext) {
+    throw new Error("Invalid image extension");
+  }
+
+  const filename = file.name;
+  const contentType = file.type;
+  const fileSize = file.size;
+
+  const { presignedUrl, objectKey } = await postPresignedUrl(
+    filename,
+    contentType,
+    fileSize
+  );
+  await uploadToS3(presignedUrl, file, ext);
+
+  return objectKey;
+};

--- a/src/services/s3Upload.ts
+++ b/src/services/s3Upload.ts
@@ -1,0 +1,22 @@
+import {
+  IMAGE_EXTENSION_TO_CONTENT_TYPE,
+  type ImageExtension
+} from "@/utils/image";
+
+export const uploadToS3 = async (
+  presignedUrl: string,
+  file: File,
+  ext: ImageExtension
+) => {
+  const res = await fetch(presignedUrl, {
+    method: "PUT",
+    headers: {
+      "Content-Type": IMAGE_EXTENSION_TO_CONTENT_TYPE[ext]
+    },
+    body: file
+  });
+
+  if (!res.ok) {
+    throw new Error("S3 upload failed");
+  }
+};

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -3,7 +3,7 @@ export type User = {
   nickname: string;
   email: string;
   introduction: string;
-  profileImageKey: string;
+  profileImageKey: string | null;
   socialProvider: string;
   role: string;
   isNicknameRequired: boolean;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -3,6 +3,20 @@ export type User = {
   nickname: string;
   email: string;
   introduction: string;
+  profileImageKey: string;
+  socialProvider: string;
   role: string;
   isNicknameRequired: boolean;
+};
+
+// export type imageUpload = {
+//   filename: string;
+//   contentType: string;
+//   fileSize: number;
+// };
+
+export type imageUploadResponse = {
+  presignedUrl: string;
+  objectKey: string;
+  expiresIn: number;
 };

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,0 +1,27 @@
+export const IMAGE_EXTENSION_TO_CONTENT_TYPE = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png"
+} as const;
+
+export type ImageExtension = keyof typeof IMAGE_EXTENSION_TO_CONTENT_TYPE;
+
+export const getExtension = (file: File): ImageExtension | null => {
+  const ext = file.name.split(".").pop()?.toLowerCase();
+  if (!ext) return null;
+  if (!(ext in IMAGE_EXTENSION_TO_CONTENT_TYPE)) return null;
+  return ext as ImageExtension;
+};
+
+export const validateProfileImage = (file: File): ImageExtension | null => {
+  const ext = getExtension(file);
+  if (!ext) return null;
+
+  const expectedType = IMAGE_EXTENSION_TO_CONTENT_TYPE[ext];
+  if (file.type !== expectedType) return null;
+
+  return ext;
+};
+
+export const getProfileImageUrl = (key?: string) =>
+  key ? `${import.meta.env.VITE_S3_PUBLIC_BASE_URL}/${key}` : undefined;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어 주세요.

Closes: #35 

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능)
- 서버에서 presignedUrl 받아 직접 s3 버킷에 업로드하는 로직 구현
- 기존에 사용하던 usePatchProfile 훅에 이미지 캐싱 코드 추가
- 헤더에 저장된 프로필 이미지 로드

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해 주세요.
<img width="600" height="auto" alt="image" src="https://github.com/user-attachments/assets/f95fda36-0da4-41b8-b4c5-e7480f73cac2" />
<img width="300" height="auto" alt="image" src="https://github.com/user-attachments/assets/1d3f83f8-ff8d-4608-a291-b18097f991c9" />


## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 출시 노트

* **새로운 기능**
  * 프로필 이미지 업로드 서비스(사전 서명 URL 사용) 및 S3 업로드 지원.
  * 사용자 발견(팔로우) 페이지 추가.

* **개선**
  * 프로필 업로드 UI: 라이브 미리보기, 업로드/제거 버튼, 유효성 검사 및 재업로드 지원.
  * 헤더 아바타 개선: 프로필 이미지가 있으면 실제 이미지 표시, 초기값은 이니셜 대체.

* **기타 변경**
  * 일부 라우트 경로 수정: calendar→calendars, find→finds, setting→settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->